### PR TITLE
kagura: create thermanager.xml based on stock thermal config files

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -1,302 +1,163 @@
 <thermanager>
-	<resources>
-		<!-- thermal zones -->
-		<resource name="bms"  type="tz">/sys/class/thermal/thermal_zone0</resource>
-		<resource name="battery"  type="tz">/sys/class/thermal/thermal_zone1</resource>
-		<resource name="pa_therm1" type="tz">/sys/class/thermal/thermal_zone2</resource>
-		<resource name="xo_therm" type="tz">/sys/class/thermal/thermal_zone3</resource>
-		<resource name="xo_therm_buf" type="tz">/sys/class/thermal/thermal_zone4</resource>
-		<resource name="case_therm" type="tz">/sys/class/thermal/thermal_zone5</resource>
-		<resource name="bl_therm" type="tz">/sys/class/thermal/thermal_zone6</resource>
+    <resources>
 
-		<resource name="tsens_tz_sensor0"  type="tz">/sys/class/thermal/thermal_zone7</resource>
-		<resource name="tsens_tz_sensor1"  type="tz">/sys/class/thermal/thermal_zone8</resource>
-		<resource name="tsens_tz_sensor2"  type="tz">/sys/class/thermal/thermal_zone9</resource>
-		<resource name="tsens_tz_sensor3"  type="tz">/sys/class/thermal/thermal_zone10</resource> <!-- cpu0 -->
-		<resource name="tsens_tz_sensor4"  type="tz">/sys/class/thermal/thermal_zone11</resource> <!-- cpu1 -->
-		<resource name="tsens_tz_sensor5"  type="tz">/sys/class/thermal/thermal_zone12</resource> <!-- cpu4 -->
-		<resource name="tsens_tz_sensor6"  type="tz">/sys/class/thermal/thermal_zone13</resource> <!-- cpu2 -->
-		<resource name="tsens_tz_sensor7"  type="tz">/sys/class/thermal/thermal_zone14</resource> <!-- cpu3 -->
-		<resource name="tsens_tz_sensor8"  type="tz">/sys/class/thermal/thermal_zone15</resource> <!-- cpu5 -->
-		<resource name="tsens_tz_sensor9"  type="tz">/sys/class/thermal/thermal_zone16</resource> <!-- gpu0 -->
-		<resource name="tsens_tz_sensor10" type="tz">/sys/class/thermal/thermal_zone17</resource> <!-- gpu1 -->
+        <!-- thermal zones -->
+        <resource name="bms"  type="tz">/sys/class/thermal/thermal_zone0</resource>
+        <resource name="msm_therm" type="tz">/sys/class/thermal/thermal_zone24</resource>
+        <resource name="emmc_therm" type="tz">/sys/class/thermal/thermal_zone25</resource>
 
-		<resource name="pm8950_tz" type="tz">/sys/class/thermal/thermal_zone18</resource>
-		<resource name="pa_therm0" type="tz">/sys/class/thermal/thermal_zone20</resource>
+        <!-- cpu clusters -->
+        <resource name="cluster-0-max-clk" type="sysfs">/sys/module/msm_performance/parameters/cpu_max_freq</resource>
+        <resource name="cluster-1-max-clk" type="sysfs">/sys/module/msm_performance/parameters/cpu_max_freq</resource>
 
-		<resource name="temp-core" type="union">
-			<resource name="tsens_tz_sensor0" />
-			<resource name="tsens_tz_sensor1" />
-			<resource name="tsens_tz_sensor2" />
-		</resource>
+        <!-- adreno -->
+        <resource name="adreno-max-clk" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
 
-		<resource name="temp-cluster-a53" type="union">
-			<resource name="tsens_tz_sensor3" />
-			<resource name="tsens_tz_sensor4" />
-			<resource name="tsens_tz_sensor6" />
-			<resource name="tsens_tz_sensor7" />
-		</resource>
+        <!--- charging speed -->
+        <resource name="charge_speed" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
 
-		<resource name="temp-cluster-a72" type="union">
-			<resource name="tsens_tz_sensor5" />
-			<resource name="tsens_tz_sensor8" />
-		</resource>
+        <!-- shutdown -->
+        <resource name="shutdown" type="halt" delay="5" />
 
-		<resource name="temp-adreno-510" type="union">
-			<resource name="tsens_tz_sensor9"  />
-			<resource name="tsens_tz_sensor10" />
-		</resource>
+    </resources>
 
-		<!-- generic cpufreq -->
-		<resource name="cluster-a53" type="sysfs">/sys/module/msm_performance/parameters/cpu_max_freq</resource>
-		<resource name="cluster-a72" type="sysfs">/sys/module/msm_performance/parameters/cpu_max_freq</resource>
+    <control name="shutdown">
+        <mitigation level="off" />
+        <mitigation level="1"><value resource="shutdown"/></mitigation>
+    </control>
 
-		<!-- hotplugging -->
-		<resource name="thermal-max-cpus" type="sysfs">/sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus</resource>
+    <!-- cluster 0 clocks -->
+    <control name="cluster-0-clk">
+        <mitigation level="off"><value resource="cluster-0-max-clk">0:4294967295</value></mitigation>
+        <mitigation level="1"><value resource="cluster-0-max-clk">0:1478400</value></mitigation>
+        <mitigation level="2"><value resource="cluster-0-max-clk">0:1324800</value></mitigation>
+        <mitigation level="3"><value resource="cluster-0-max-clk">0:1113600</value></mitigation>
+        <mitigation level="4"><value resource="cluster-0-max-clk">0:1036800</value></mitigation>
+        <mitigation level="5"><value resource="cluster-0-max-clk">0:844800</value></mitigation>
+        <mitigation level="6"><value resource="cluster-0-max-clk">0:729600</value></mitigation>
+        <mitigation level="7"><value resource="cluster-0-max-clk">0:422400</value></mitigation>
+        <mitigation level="8"><value resource="cluster-0-max-clk">0:307200</value></mitigation>
+    </control>
 
-		<!-- device-specific -->
-		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
-		<resource name="charge_speed" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
-		<resource name="charging_enabled" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
+    <!-- cluster 1 clocks -->
+    <control name="cluster-1-clk">
+        <mitigation level="off"><value resource="cluster-1-max-clk">2:4294967295</value></mitigation>
+        <mitigation level="1"><value resource="cluster-1-max-clk">2:1478400</value></mitigation>
+        <mitigation level="2"><value resource="cluster-1-max-clk">2:1324800</value></mitigation>
+        <mitigation level="3"><value resource="cluster-1-max-clk">2:1113600</value></mitigation>
+        <mitigation level="4"><value resource="cluster-1-max-clk">2:1036800</value></mitigation>
+        <mitigation level="5"><value resource="cluster-1-max-clk">2:883200</value></mitigation>
+        <mitigation level="6"><value resource="cluster-1-max-clk">2:729600</value></mitigation>
+        <mitigation level="7"><value resource="cluster-1-max-clk">2:403200</value></mitigation>
+        <mitigation level="8"><value resource="cluster-1-max-clk">2:307200</value></mitigation>
+    </control>
 
-		<!-- TODO: -->
-		<resource name="modem" type="echo" />
+    <!-- adreno clocks -->
+    <control name="adreno-clk">
+        <mitigation level="off"><value resource="adreno-max-clk">624000000</value></mitigation>
+        <mitigation level="1"><value resource="adreno-max-clk">133000000</value></mitigation>
+    </control>
 
-		<resource name="shutdown" type="halt" delay="5" />
+    <!-- charging levels -->
+    <control name="charging">
+        <mitigation level="off"><value resource="charge_speed">0</value></mitigation>
+        <mitigation level="1"><value resource="charge_speed">2</value></mitigation>
+        <mitigation level="2"><value resource="charge_speed">5</value></mitigation>
+        <mitigation level="3"><value resource="charge_speed">8</value></mitigation>
+        <mitigation level="4"><value resource="charge_speed">9</value></mitigation>
+        <mitigation level="5"><value resource="charge_speed">11</value></mitigation>
+        <mitigation level="6"><value resource="charge_speed">12</value></mitigation>
+        <mitigation level="7"><value resource="charge_speed">13</value></mitigation>
+    </control>
 
-	</resources>
+    <!-- throttling -->
+    <configuration sensor="emmc_therm">
+        <threshold>
+            <mitigation name="cluster-0-clk" level="off" />
+            <mitigation name="cluster-1-clk" level="off" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="off" />
+        </threshold>
+        <threshold trigger="45000" clear="42000">
+            <mitigation name="cluster-0-clk" level="off" />
+            <mitigation name="cluster-1-clk" level="off" />
+            <mitigation name="charging" level="1" />
+            <mitigation name="adreno-clk" level="off" />
+        </threshold>
+        <threshold trigger="47700" clear="45000">
+            <mitigation name="cluster-0-clk" level="1" />
+            <mitigation name="cluster-1-clk" level="1" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="1" />
+        </threshold>
+        <threshold trigger="48900" clear="47700">
+            <mitigation name="cluster-0-clk" level="2" />
+            <mitigation name="cluster-1-clk" level="2" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="2" />
+        </threshold>
+        <threshold trigger="50200" clear="48900">
+            <mitigation name="cluster-0-clk" level="3" />
+            <mitigation name="cluster-1-clk" level="3" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="3" />
+        </threshold>
+        <threshold trigger="51400" clear="50200">
+            <mitigation name="cluster-0-clk" level="4" />
+            <mitigation name="cluster-1-clk" level="4" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="4" />
+        </threshold>
+        <threshold trigger="52500" clear="51400">
+            <mitigation name="cluster-0-clk" level="5" />
+            <mitigation name="cluster-1-clk" level="5" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="5" />
+        </threshold>
+        <threshold trigger="53500" clear="52500">
+            <mitigation name="cluster-0-clk" level="6" />
+            <mitigation name="cluster-1-clk" level="6" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="5" />
+        </threshold>
+        <threshold trigger="54700" clear="53500">
+            <mitigation name="cluster-0-clk" level="7" />
+            <mitigation name="cluster-1-clk" level="7" />
+            <mitigation name="adreno-clk" level="off" />
+            <mitigation name="charging" level="6" />
+        </threshold>
+        <threshold trigger="55700" clear="54700">
+            <mitigation name="cluster-0-clk" level="8" />
+            <mitigation name="cluster-1-clk" level="8" />
+            <mitigation name="adreno-clk" level="1" />
+            <mitigation name="charging" level="6" />
+        </threshold>
+        <threshold trigger="63000" clear="60000">
+            <mitigation name="cluster-0-clk" level="8" />
+            <mitigation name="cluster-1-clk" level="8" />
+            <mitigation name="adreno-clk" level="1" />
+            <mitigation name="charging" level="7" />
+        </threshold>
+    </configuration>
 
-	<control name="battery_protect">
-		<mitigation level="off"><value resource="charging_enabled">1</value></mitigation>
-		<mitigation level="1"><value resource="charging_enabled">0</value></mitigation>
-		<mitigation level="2"><value resource="shutdown" /></mitigation>
-	</control>
+    <!-- burn-out protection -->
+    <configuration sensor="emmc_therm">
+        <threshold>
+            <mitigation name="shutdown" level="off" />
+        </threshold>
+        <threshold trigger="74000" clear="63000">
+            <mitigation name="shutdown" level="1" />
+        </threshold>
+    </configuration>
 
-	<control name="charging">
-		<mitigation level="off"><value resource="charge_speed">0</value></mitigation>
-		<mitigation level="1"><value resource="charge_speed">1</value></mitigation>
-		<mitigation level="2"><value resource="charge_speed">2</value></mitigation>
-		<mitigation level="3"><value resource="charge_speed">3</value></mitigation>
-		<mitigation level="4"><value resource="charge_speed">4</value></mitigation>
-		<mitigation level="5"><value resource="charge_speed">5</value></mitigation>
-		<mitigation level="6"><value resource="charge_speed">6</value></mitigation>
-		<mitigation level="7"><value resource="charge_speed">7</value></mitigation>
-		<mitigation level="8"><value resource="charge_speed">8</value></mitigation>
-		<mitigation level="9"><value resource="charge_speed">9</value></mitigation>
-		<mitigation level="10"><value resource="charge_speed">10</value></mitigation>
-		<mitigation level="11"><value resource="charge_speed">11</value></mitigation>
-		<mitigation level="12"><value resource="charge_speed">12</value></mitigation>
-		<mitigation level="13"><value resource="charge_speed">13</value></mitigation>
-	</control>
-
-	<control name="modem">
-		<mitigation level="off"><value resource="modem">0</value></mitigation>
-		<mitigation level="1"><value resource="modem">1</value></mitigation>
-	</control>
-
-	<control name="shutdown">
-		<mitigation level="off" />
-		<mitigation level="1"><value resource="shutdown"/></mitigation>
-	</control>
-
-	<control name="gpu">
-		<mitigation level="off"><value resource="kgsl-3d0">600000000</value></mitigation>
-		<mitigation level="1"><value resource="kgsl-3d0">510000000</value></mitigation>
-		<mitigation level="2"><value resource="kgsl-3d0">480000000</value></mitigation>
-		<mitigation level="3"><value resource="kgsl-3d0">432000000</value></mitigation>
-		<mitigation level="4"><value resource="kgsl-3d0">300000000</value></mitigation>
-		<mitigation level="5"><value resource="kgsl-3d0">266666667</value></mitigation>
-	</control>
-
-	<control name="cpu-a53">
-		<mitigation level="off"><value resource="cluster-a53">0:4294967295</value></mitigation>
-		<mitigation level="1"><value resource="cluster-a53">0:1382400</value></mitigation>
-		<mitigation level="2"><value resource="cluster-a53">0:1305600</value></mitigation>
-		<mitigation level="3"><value resource="cluster-a53">0:1190400</value></mitigation>
-		<mitigation level="4"><value resource="cluster-a53">0:1017600</value></mitigation>
-		<mitigation level="5"><value resource="cluster-a53">0:806400</value></mitigation>
-		<mitigation level="6"><value resource="cluster-a53">0:691200</value></mitigation>
-		<mitigation level="7"><value resource="cluster-a53">0:400000</value></mitigation>
-		<mitigation level="8"><value resource="shutdown" /></mitigation>
-	</control>
-
-	<control name="cpu-a72">
-		<mitigation level="off"><value resource="cluster-a57">4:4294967295</value></mitigation>
-		<mitigation level="1"><value resource="cluster-a57">4:1747200</value></mitigation>
-		<mitigation level="2"><value resource="cluster-a57">4:1612800</value></mitigation>
-		<mitigation level="3"><value resource="cluster-a57">4:1382400</value></mitigation>
-		<mitigation level="4"><value resource="cluster-a57">4:1305600</value></mitigation>
-		<mitigation level="5"><value resource="cluster-a57">4:1248000</value></mitigation>
-		<mitigation level="6"><value resource="cluster-a57">4:1190400</value></mitigation>
-		<mitigation level="7"><value resource="cluster-a57">4:1113600</value></mitigation>
-		<mitigation level="8"><value resource="cluster-a57">4:1056000</value></mitigation>
-		<mitigation level="9"><value resource="cluster-a57">4:998400</value></mitigation>
-		<mitigation level="10"><value resource="cluster-a57">4:940800</value></mitigation>
-		<mitigation level="11"><value resource="cluster-a57">4:883200</value></mitigation>
-		<mitigation level="12"><value resource="cluster-a57">4:400000</value></mitigation>
-		<mitigation level="13"><value resource="shutdown" /></mitigation>
-	</control>
-
-	<control name="hotplug-a72">
-		<mitigation level="off"><value resource="thermal-max-cpus">6</value></mitigation>
-		<mitigation level="1"><value resource="thermal-max-cpus">5</value></mitigation>
-		<mitigation level="2"><value resource="thermal-max-cpus">4</value></mitigation>
-	</control>
-
-	<!-- burn-out protection -->
-	<configuration sensor="temp-core">
-		<threshold>
-			<mitigation name="shutdown" level="off" />
-		</threshold>
-		<threshold trigger="120" clear="100">
-			<mitigation name="shutdown" level="1" />
-		</threshold>
-	</configuration>
-
-	<!-- charging -->
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="charging" level="off" />
-		</threshold>
-		<threshold trigger="490" clear="487">
-			<mitigation name="charging" level="2" />
-		</threshold>
-		<threshold trigger="500" clear="498">
-			<mitigation name="charging" level="3" />
-		</threshold>
-		<threshold trigger="510" clear="509">
-			<mitigation name="charging" level="8" />
-		</threshold>
-		<threshold trigger="516" clear="512">
-			<mitigation name="charging" level="9" />
-		</threshold>
-		<threshold trigger="525" clear="522">
-			<mitigation name="charging" level="12" />
-		</threshold>
-		<threshold trigger="590" clear="560">
-			<mitigation name="charging" level="13" />
-		</threshold>
-	</configuration>
-
-	<configuration sensor="battery">
-		<threshold>
-			<mitigation name="battery_protect" level="off" />
-		</threshold>
-		<threshold trigger="50000" clear="47000">
-			<mitigation name="battery_protect" level="1" />
-		</threshold>
-		<threshold trigger="67000" clear="60000">
-			<mitigation name="battery_protect" level="2" />
-		</threshold>
-	</configuration>
-
-	<!-- GPU -->
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="gpu" level="off" />
-		</threshold>
-		<threshold trigger="512" clear="510">
-			<mitigation name="gpu" level="2" />
-		</threshold>
-		<threshold trigger="518" clear="516">
-			<mitigation name="gpu" level="3" />
-		</threshold>
-		<threshold trigger="525" clear="522">
-			<mitigation name="gpu" level="5" />
-		</threshold>
-	</configuration>
-
-	<!-- modem -->
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="modem" level="off" />
-		</threshold>
-		<threshold trigger="530" clear="510">
-			<mitigation name="modem" level="1" />
-		</threshold>
-	</configuration>
-
-	<!-- CPU A53 -->
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="cpu-a53" level="off" />
-		</threshold>
-		<threshold trigger="508" clear="505">
-			<mitigation name="cpu-a53" level="1" />
-		</threshold>
-		<threshold trigger="510" clear="509">
-			<mitigation name="cpu-a53" level="2" />
-		</threshold>
-		<threshold trigger="512" clear="510">
-			<mitigation name="cpu-a53" level="4" />
-		</threshold>
-		<threshold trigger="518" clear="516">
-			<mitigation name="cpu-a53" level="5" />
-		</threshold>
-		<threshold trigger="525" clear="522">
-			<mitigation name="cpu-a53" level="6" />
-		</threshold>
-		<threshold trigger="550" clear="530">
-			<mitigation name="cpu-a53" level="7" />
-		</threshold>
-	</configuration>
-
-	<configuration sensor="temp-cluster-a53">
-		<threshold>
-			<mitigation name="cpu-a53" level="off" />
-		</threshold>
-		<threshold trigger="75" clear="68">
-			<mitigation name="cpu-a53" level="2" />
-		</threshold>
-		<threshold trigger="78" clear="73">
-			<mitigation name="cpu-a53" level="5" />
-		</threshold>
-		<threshold trigger="120" clear="100">
-			<mitigation name="cpu-a53" level="8" />
-		</threshold>
-	</configuration>
-
-	<!-- CPU A72 -->
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="cpu-a72" level="off" />
-		</threshold>
-		<threshold trigger="480" clear="460">
-			<mitigation name="cpu-a72" level="5" />
-		</threshold>
-		<threshold trigger="500" clear="498">
-			<mitigation name="cpu-a72" level="11" />
-		</threshold>
-		<threshold trigger="505" clear="500">
-			<mitigation name="cpu-a72" level="12" />
-		</threshold>
-	</configuration>
-
-	<configuration sensor="case_therm">
-		<threshold>
-			<mitigation name="hotplug-a72" level="off" />
-		</threshold>
-		<threshold trigger="500" clear="498">
-			<mitigation name="hotplug-a72" level="1" />
-		</threshold>
-		<threshold trigger="505" clear="500">
-			<mitigation name="hotplug-a72" level="2" />
-		</threshold>
-	</configuration>
-
-	<configuration sensor="temp-cluster-a72">
-		<threshold>
-			<mitigation name="cpu-a72" level="off" />
-		</threshold>
-		<threshold trigger="75" clear="68">
-			<mitigation name="cpu-a72" level="10" />
-		</threshold>
-		<threshold trigger="78" clear="73">
-			<mitigation name="cpu-a72" level="11" />
-		</threshold>
-		<threshold trigger="120" clear="100">
-			<mitigation name="cpu-a72" level="13" />
-		</threshold>
-	</configuration>
+    <!-- battery protection -->
+    <configuration sensor="bms">
+        <threshold>
+            <mitigation name="shutdown" level="off" />
+        </threshold>
+        <threshold trigger="67000" clear="63000">
+            <mitigation name="shutdown" level="1" />
+        </threshold>
+    </configuration>
 
 </thermanager>


### PR DESCRIPTION
* Based on the actual values used by Sony
* Based on the actual sensors used by Sony

note: it looks quite sparse copared to previous platforms, but long
gone are the days we would measure individual cores. The high perf
cores of modern SoC means that huge, brief temperature swings on
each core are normal and correct.

Today we need to measure only the overall temperatures of each
component, which (for us) means the benefit of a nice, simple
thermal config.

Signed-off-by: Adam Farden <adam@farden.cz>