### PR TITLE
kagura: fix headphones voice in call

### DIFF
--- a/rootdir/system/etc/mixer_paths.xml
+++ b/rootdir/system/etc/mixer_paths.xml
@@ -1693,6 +1693,10 @@
         <path name="voicemmode1-call incall-music-bt" />
     </path>
 
+    <path name="voicemmode1-call headphones">
+        <path name="voicemmode1-call"/>
+    </path>
+
     <path name="voicemmode2-call">
         <ctl name="SLIM_0_RX_Voice Mixer VoiceMMode2" value="1" />
         <ctl name="VoiceMMode2_Tx Mixer SLIM_0_TX_MMode2" value="1" />


### PR DESCRIPTION
06-09 11:46:35.216 E/audio_route(585): unable to find path 'voicemmode1-call headphones'

Signed-off-by: David Viteri <davidteri91@gmail.com>