### PR TITLE
Revert "sony: kagura: Enable wakeup gesture"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -26,4 +26,4 @@ BOARD_KERNEL_CMDLINE += androidboot.hardware=kagura
 #Reserve space for data encryption (23857201152-16384)
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 23857184768
 
-TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
+#TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -89,7 +89,7 @@
     <integer name="config_screenBrightnessDark">5</integer>
 
     <!-- Whether device supports double tap to wake -->
-    <bool name="config_supportDoubleTapWake">true</bool>
+    <bool name="config_supportDoubleTapWake">false</bool>
 
     <!-- MMS user agent prolfile url -->
     <string name="config_mms_user_agent_profile_url" translatable="false">http://uaprof.sonymobile.com/F8331R3901.xml</string>


### PR DESCRIPTION
Using DT2W breaks touch when coming from deepsleep and using the Powerbutton to wake the device. That happens on at least the hybrid incell touchscreen.