### PR TITLE
kagura: remove not needed daemon fingerprint

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -68,7 +68,6 @@ PRODUCT_PACKAGES += \
 
 # Fingerprint HAL
 PRODUCT_PACKAGES += \
-    fingerprintd \
     fingerprint.kagura
 
 # NFC config


### PR DESCRIPTION
daemon fingerprint is not more on android oreo it was replaced by android.hardware.biometrics.fingerprint

Signed-off-by: David Viteri <davidteri91@gmail.com>