### PR TITLE
Integrate the Camera Augmented Sensing Helper and its ToF calibration

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -34,4 +34,6 @@ BOARD_SYSTEMIMAGE_PARTITION_SIZE := 6197084160
 # Reserve space for data encryption (23857201152-16384)
 BOARD_USERDATAIMAGE_PARTITION_SIZE := 23857184768
 
+TARGET_USES_CASH_EXTENSION := true
+
 #TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"

--- a/device.mk
+++ b/device.mk
@@ -52,6 +52,11 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Headset_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Headset_cal.acdb \
     $(DEVICE_PATH)/vendor/etc/acdbdata/Speaker_cal.acdb:$(TARGET_COPY_OUT_VENDOR)/etc/acdbdata/Speaker_cal.acdb
 
+# Focus calibration
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/tof_focus_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/tof_focus_calibration.xml
+
+# NFC Configuration
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/libnfc-brcm.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-brcm.conf \
     $(DEVICE_PATH)/vendor/etc/libnfc-nxp.conf:$(TARGET_COPY_OUT_VENDOR)/etc/libnfc-nxp.conf
@@ -86,6 +91,12 @@ PRODUCT_PACKAGES += \
 # SAR
 PRODUCT_PACKAGES += \
     TransPowerSensors
+
+# Camera Augmented Sensing Helper
+PRODUCT_PACKAGES += \
+   libpolyreg \
+   cashsvr \
+   libcashctl
 
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi

--- a/rootdir/vendor/etc/tof_focus_calibration.xml
+++ b/rootdir/vendor/etc/tof_focus_calibration.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<tof_focus_calibration>
+    <tof_focus>
+        <focus millimeters="103 116 132 166 275 376 455 524 625 726 1015"
+               focus_step="10000000 8802976 8233618 6723431 4486076 3474713
+                           3065622  2991282 2545576 2203557 1851378"/>
+    </tof_focus>
+</tof_focus_calibration>


### PR DESCRIPTION
Add libcashctl, cashsvr, libpolyreg to the build, declare
TARGET_USES_CASH_EXTENSION to build the code in the camera HAL
and copy the tof_focus_calibration XML.