### PR TITLE
add logic to set TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,7 +14,14 @@
 
 include device/sony/tone/PlatformConfig.mk
 
-TARGET_BOOTLOADER_BOARD_NAME := tone
+TARGET_BOOTLOADER_BOARD_NAME := unknown
+ifneq (,$(filter %f8331,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := F8331
+else ifneq (,$(filter %f8332,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := F8332
+else
+$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+endif
 
 # Platform
 PRODUCT_PLATFORM := tone


### PR DESCRIPTION
Set TARGET_BOOTLOADER_BOARD_NAME to the variant-specific board-name
(i.e. F8331, F8332).  This causes the "board" variable in
"android-info.txt" to be populated correctly, which fixes
updatepackage zips.