### PR TITLE
[WIP] device: Add RGBC-IR CASH calibration

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -56,6 +56,9 @@ PRODUCT_COPY_FILES += \
 # Focus calibration
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/tof_focus_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/tof_focus_calibration.xml
+# RGBC-IR calibration
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/cash_expcol_calibration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/cash_expcol_calibration.xml
 
 # NFC Configuration
 PRODUCT_COPY_FILES += \

--- a/rootdir/vendor/etc/cash_expcol_calibration.xml
+++ b/rootdir/vendor/etc/cash_expcol_calibration.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- RGBC-IR calibration file for Xperia XZ -->
+<!-- TCS3490 sensor -->
+<!-- Values compiled by Daniel Aniq -->
+<cash_expcol_calibration>
+    <clear_iso>
+        <rgbc_clear_iso_exptime
+               clear_values="1 16 32 53 83 150 500 1000 2500 3500 4500 6500 8000"
+               iso_values="3200 800 640 250 200 125 100 80 50 40 40 40 40"
+               exposure_times="62500000 40000000 31250000 20000000 10000000 8000000 5000000 4000000 2000000 1562500 1250000 625000 625000"/>
+        <rgbc_clear_limits min_range="1" max_range="8000"/>
+    </clear_iso>
+</cash_expcol_calibration>


### PR DESCRIPTION
This enables RGBC-IR support in CASH for kagura.

Values compiled by Daniel Aniq by manual testing and comparing with stock firmware.